### PR TITLE
defaults set to the url for the specific operating system. Also changed ...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,10 @@
-default['vagrant']['url'] = nil
-default['vagrant']['checksum'] = nil
+default['vagrant']['url']['windows'] = "http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/Vagrant_1.2.7.msi"
+default['vagrant']['url']['osx'] = "http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/Vagrant-1.2.7.dmg"
+default['vagrant']['url']['deb'] = "http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/vagrant_1.2.7_x86_64.deb"
+default['vagrant']['url']['rpm'] = "http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/vagrant_1.2.7_x86_64.rpm"
+default['vagrant']['checksum']['windows'] = nil
+default['vagrant']['checksum']['osx'] = nil
+default['vagrant']['checksum']['deb'] = nil
+default['vagrant']['checksum']['rpm'] = nil
 default['vagrant']['plugins'] = []
 default['vagrant']['msi_version'] = ""

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -1,5 +1,5 @@
 remote_file "#{Chef::Config[:file_cache_path]}/vagrant.deb" do
-  source node['vagrant']['url']
+  source node['vagrant']['url']['deb']
   checksum node['vagrant']['checksum']
   notifies :install, "dpkg_package[vagrant]", :immediately
 end

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -1,5 +1,5 @@
 dmg_package "Vagrant" do
-  source node['vagrant']['url']
+  source node['vagrant']['url']['osx']
   checksum node['vagrant']['checksum']
   type "pkg"
   package_id "com.vagrant.vagrant"

--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -1,5 +1,5 @@
 remote_file "#{Chef::Config[:file_cache_path]}/vagrant.rpm" do
-  source node['vagrant']['url']
+  source node['vagrant']['url']['rpm']
   checksum node['vagrant']['checksum']
   notifies :install, "rpm_package[vagrant]", :immediately
 end

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -1,5 +1,12 @@
 windows_package "Vagrant #{node['vagrant']['msi_version']}" do
-  source node['vagrant']['url']
+  source node['vagrant']['url']['windows']
   checksum node['vagrant']['checksum']
   action :install
+end
+
+env "PATH" do
+	not_if{
+		ENV['PATH'] =~ /HashiCorp/ 	
+	}
+	value "#{ENV['PATH']};c:/HashiCorp/Vagrant/bin"
 end


### PR DESCRIPTION
...the checksum defaults for each operating system, currently still just nil so this will have to be implemented later.

The change in the windows recipe simply adds the vagrant command to the system's PATH so we can call 'vagrant' soon after running the cookbook on windows machines.

UNTESTED FOR  DEB/OSX/RPM MACHINES!

Tested on Windows machine, works great on Windows 7 Enterprise 2008 R2 Standard.
