### PR TITLE
Change metadata depends to recommends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,5 @@ supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.3'
 
-depends "dmg"
-depends "windows"
+recommends 'dmg'
+recommends 'windows'


### PR DESCRIPTION
I imagine the merits of using `recommends` instead of `depends` are debatable, but depending on dmg and windows is excessive for linux environments.

This changes the use of `depends` to `recommends` instead.

I'd be fine with `suggests` also if it is better supported by older chef clients.

Also changed some quotes to be more consistent.
