### PR TITLE
Fix emphasis on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Vagrant does not specifically list supported platforms on the project web site. 
 - Linux (deb-package based platforms, e.g., Debian and Ubuntu)
 - Linux (rpm-packaged based platforms, e.g., RHEL and CentOS)
 
-Other platforms are not supported. This cookbook attempts to exit gracefully in places where unsupported platforms may cause an issue, but it is --strongly recommended-- that this cookbook not be used on an unsupported platform's node run list or used as a dependency for cookbooks used on unsupported platforms.
+Other platforms are not supported. This cookbook attempts to exit gracefully in places where unsupported platforms may cause an issue, but it is __strongly recommended__ that this cookbook not be used on an unsupported platform's node run list or used as a dependency for cookbooks used on unsupported platforms.
 
 ## Tested with Test Kitchen
 


### PR DESCRIPTION
# Description

I believe that `--strongly recommended--` was meant to be emphasised.

## Issues Resolved

N/A

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
