### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- resolved cookstyle error: test/fixtures/cookbooks/wintest/resources/authorize_service.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 2.0.6 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/test/fixtures/cookbooks/wintest/resources/authorize_service.rb
+++ b/test/fixtures/cookbooks/wintest/resources/authorize_service.rb
@@ -9,6 +9,7 @@
 # Took most of the code from chef/lib/chef/provider/service/windows.rb
 
 provides :authorize_service
+unified_mode true
 property :service, String, required: true
 property :user, String, required: true
 


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with test/fixtures/cookbooks/wintest/resources/authorize_service.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)